### PR TITLE
Fix PQM merging with old versions

### DIFF
--- a/quasar.go
+++ b/quasar.go
@@ -297,8 +297,10 @@ func (q *Quasar) QueryStatisticalValuesStream(ctx context.Context, id uuid.UUID,
 		return nil, bte.Chan(err), 0, 0
 	}
 	rvv, rve := tr.QueryStatisticalValues(ctx, start, end, pointwidth)
-	return q.pqm.MergeQueryStatisticalValuesStream(ctx, id, start, end, pointwidth, rvv, rve)
-	//return rvv, rve, tr.Generation(), 0
+	if gen == LatestGeneration {
+		return q.pqm.MergeQueryStatisticalValuesStream(ctx, id, start, end, pointwidth, rvv, rve)
+	}
+	return rvv, rve, tr.Generation(), 0
 }
 
 func (q *Quasar) QueryWindow(ctx context.Context, id uuid.UUID, start int64, end int64,
@@ -337,8 +339,10 @@ func (q *Quasar) QueryWindow(ctx context.Context, id uuid.UUID, start int64, end
 		return nil, bte.Chan(err), 0, 0
 	}
 	rvv, rve := tr.QueryWindow(ctx, start, end, width, depth)
-	return q.pqm.MergedQueryWindow(ctx, id, start, end, width, rvv, rve)
-	//return rvv, rve, tr.Generation(), 0
+	if gen == LatestGeneration {
+		return q.pqm.MergedQueryWindow(ctx, id, start, end, width, rvv, rve)
+	}
+	return rvv, rve, tr.Generation(), 0
 }
 
 // func (q *Quasar) QueryGeneration(ctx context.Context, id uuid.UUID) (uint64, bte.BTE) {


### PR DESCRIPTION
It seems that values from PQM are sometimes used even when not querying latest version and that creates some rather unexpected results. This fixes that behavior.