### PR TITLE
Fix window aggregation

### DIFF
--- a/qtree/qtree.go
+++ b/qtree/qtree.go
@@ -1221,6 +1221,17 @@ func (n *QTreeNode) QueryWindow(ctx context.Context, end int64, nxtstart *int64,
 					//This is the first window
 					wctx.Active = true
 					*nxtstart += int64(width)
+					for n.vector_block.Time[i] >= *nxtstart {
+						n.emitWindowContext(ctx, rv, width, wctx, rve)
+						if bte.ChkContextError(ctx, rve) {
+							return
+						}
+						if *nxtstart >= end {
+							wctx.Done = true
+							return
+						}
+						*nxtstart += int64(width)
+					}
 					add()
 				}
 			}


### PR DESCRIPTION
I think windowing query seems to not consider holes before first record in vector node. For instance after running this script (I am using the python library):
```
import btrdb4
import uuid
uu = uuid.UUID('b48b3559-bc60-414d-bcc6-1b85d4314161')
conn = btrdb4.Connection("127.0.0.1:4410")
b = conn.newContext()
s = b.streamFromUUID(uu)
import time
s = b.create(uu, "a/b/c", {"created_by": b"me", "time_created": bytes(str(time.time()).encode("utf-8"))})
s.exists()
version = s.insert(((1,1000),(2,1500),(3,2000)))
s.flush()
print("rawpoints")
for rawpoint, version in s.rawValues(0,7):
  print("{0}: {1}".format(rawpoint,version))
print("stats")
for spoint in s.windows(0,10,1):
   print(str(spoint)) 

``` 
the output is 
``` 
rawpoints
RawPoint(1, 1000.0): 11
RawPoint(2, 1500.0): 11
RawPoint(3, 2000.0): 11
stats
(StatPoint(0, 1000.0, 1000.0, 1000.0, 1), 11)
(StatPoint(1, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(2, 1500.0, 1500.0, 1500.0, 1), 11)
(StatPoint(3, 2000.0, 2000.0, 2000.0, 1), 11)
(StatPoint(4, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(5, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(6, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(7, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(8, 0.0, 0.0, 0.0, 0), 11)
``` 
which is wrong. The fix I am proposing makes the output be like this:
``` 
rawpoints
RawPoint(1, 1000.0): 11
RawPoint(2, 1500.0): 11
RawPoint(3, 2000.0): 11
stats
(StatPoint(0, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(1, 1000.0, 1000.0, 1000.0, 1), 11)
(StatPoint(2, 1500.0, 1500.0, 1500.0, 1), 11)
(StatPoint(3, 2000.0, 2000.0, 2000.0, 1), 11)
(StatPoint(4, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(5, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(6, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(7, 0.0, 0.0, 0.0, 0), 11)
(StatPoint(8, 0.0, 0.0, 0.0, 0), 11)
``` 
while hopefully not breaking anything :)
