### PR TITLE
Fix handling of faulty inserts

### DIFF
--- a/bte/errors.go
+++ b/bte/errors.go
@@ -262,3 +262,6 @@ const InvariantFailure = 500
 
 // Haha lol
 const NotImplemented = 501
+
+// Returned when insert contains records with duplicated or already existing timestamps
+const DuplicateTimestamps = 502

--- a/internal/bstore/blockstore.go
+++ b/internal/bstore/blockstore.go
@@ -290,7 +290,6 @@ func (bs *BlockStore) ObtainGeneration(ctx context.Context, id uuid.UUID) (*Gene
 		mtx.Lock()
 	}
 	bs.glock.Unlock()
-
 	gen := &Generation{
 		cblocks: make([]*Coreblock, 0, 8192),
 		vblocks: make([]*Vectorblock, 0, 8192),
@@ -307,10 +306,15 @@ func (bs *BlockStore) ObtainGeneration(ctx context.Context, id uuid.UUID) (*Gene
 		//previously we just made the stream like this:
 		//gen.Cur_SB = NewSuperblock(id)
 	}
-
 	gen.New_SB = gen.Cur_SB.CloneInc()
 	gen.blockstore = bs
 	return gen, nil
+}
+
+func (gen *Generation) Release() {
+	gen.blockstore.glock.RLock()
+	gen.blockstore._wlocks[UUIDToMapKey(*gen.Uuid())].Unlock()
+	gen.blockstore.glock.RUnlock()
 }
 
 //The returned address map is primarily for unit testing

--- a/qtree/qtree_utils.go
+++ b/qtree/qtree_utils.go
@@ -68,6 +68,16 @@ func (s RecordSlice) Less(i, j int) bool {
 	return s[i].Time < s[j].Time
 }
 
+func (tr *QTree) Release() {
+	if tr.commited {
+		log.Panicf("Tree alredy comitted")
+	}
+	if tr.gen == nil {
+		log.Panicf("Release on non-write-tree")
+	}
+	tr.gen.Release()
+}
+
 func (tr *QTree) Commit() bte.BTE {
 	if tr.commited {
 		log.Panicf("Tree alredy comitted")


### PR DESCRIPTION
Hello, 
I noticed that while BTrDB does not seem to be supposed to support overwriting records(duplicate timestamps in one insert or inserting records with already existing timestamps) such behavior is not strictly enforced. There is a check in QtreeNode InsertValues function, but it catches these errors only in some cases. What I think have experienced firsthand are these situations:

- Duplicates are successfuly inserted (that means, multiple records with the same timestamp are in one version of the tree) and written without any notice and thus silently corrupting the state. System continues to ingest data and answer queries, but all queries targeting windows that contain these duplicates return incorrect statistics.
- Duplicates are inserted successfully but one of the following (correct without any duplicates) inserts triggers the error. The correct insert is truncated and correct records are lost while the duplicates remain in the tree.
- On some special cases the duplicates can make otherwise shallow tree grow very long branches (when all the duplicates are in some really small time interval for example) which might be impossible to delete or shorten in following versions without deleting even the correct records from previous inserts that are in that leaf. 

My proposed changes fix most of this behavior. I had some troubles understanding the error returning and panicing patterns in insert, so hopefully simply error returning is ok. There should not be too big of a performance penalty from using those two hashtables and I removed one sort in ConvertToCore function :) 

These changes make BTrDB err out on any duplicate-containing insert and might even throw away the whole batch from PQM which might be a bit too harsh but it is still better than the situations I encountered I think. There is also a different approach possible to simply choose one of the duplicated records and write only that one along with all the nonduplicate records from a batch (possibly with a bit different treatment if for ex. the duplicates occur inside one insert call etc.). If you feel that this approach would be better I can rework it to this behavior.  

What this currently does not fix is the situation when there are two records with duplicated timestamps - one in tree and one in PQM buffer. Queries on the latest version (with uncommited records) of stream return incorrect statistics but it is not really fixable as the query does not even read raw records (it is of course fixable in rawvalues query but I didn't handle it either). 

I reasonably tested my changes using the tests from brtdb go library - there was one testcase which was inserting duplicates deliberately, that confused me a little bit - and the whole thing seems to be working OK. However I am not a Golang pro so I will be grateful for any suggestions as this is a bit larger change and surely more tweaks and reviews are necessary.

Hope this would help the project!
Filip