### PR TITLE
bump to latest master github.com/ceph/go-ceph

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,11 +19,17 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fb010e5492b42a769e5305806dcb46ea3999a747cc955dace445ff6b7952a19a"
+  digest = "1:6a0610e8a334b6c63552e9b910886806f5707c38b6abf16ca2317e128813b494"
   name = "github.com/ceph/go-ceph"
-  packages = ["rados"]
+  packages = [
+    "internal/cutil",
+    "internal/errutil",
+    "internal/retry",
+    "internal/timespec",
+    "rados",
+  ]
   pruneopts = "UT"
-  revision = "b2d948844f193f694ddac05f1fd325e91dd2926c"
+  revision = "512d1edd8fcd101dfe3fc42bd17483fc710e56e4"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
This fixes issue with building "on my machine" where otherwise warning is generated and that prevents make to succeed.

I haven't test beyond this fix.
Is there other way to avoid warring?

~~~~~
cgo-gcc-prolog: In function ‘_cgo_1a8d6c2cfe13_Cfunc_rados_read_op_omap_get_vals’: 
cgo-gcc-prolog:529:2: warning: ‘rados_read_op_omap_get_vals’ is deprecated [-Wdeprecated-declarations]
In file included from ../vendor/github.com/ceph/go-ceph/rados/ioctx.go:6:
/usr/include/rados/librados.h:3400:21: note: declared here    
 3400 | CEPH_RADOS_API void rados_read_op_omap_get_vals(rados_read_op_t read_op,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~ 
~~~~~